### PR TITLE
Add Render deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,23 @@ A forensic dashboard for visualizing and reporting Bluetooth Low Energy (BLE), W
 
 ## **Requirements**
 - Python 3.8+
-- See `requirements.txt` for dependencies
+- See `Requirements` for dependencies
 
 ---
 
 ## **Quick Start (Local)**
 ```bash
-pip install -r requirements.txt
-python ble_dashboard.py
+pip install -r Requirements
+python app.py
+```
+
+---
+
+## **Live Demo on Render**
+1. Commit the provided `render.yaml` and `app.py` to your repository.
+2. Push to GitHub and create a new web service on [Render](https://render.com/).
+3. Render will automatically install the requirements and start the app using `gunicorn`.
+4. Access the dashboard via the URL provided by Render.
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -1,0 +1,8 @@
+import os
+from Script import app
+
+server = app.server
+
+if __name__ == '__main__':
+    port = int(os.environ.get('PORT', 8050))
+    app.run_server(host='0.0.0.0', port=port)

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,6 @@
+services:
+  - type: web
+    name: ble-security-dashboard
+    env: python
+    buildCommand: pip install -r Requirements
+    startCommand: gunicorn app:server --bind 0.0.0.0:$PORT


### PR DESCRIPTION
## Summary
- add `app.py` for serving the Dash app
- add `render.yaml` blueprint for Render web service
- update README with quick start and Render deployment docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842513465b483259e4e229b6b3cba80