### PR TITLE
Fix duplicate warning for missing security notices

### DIFF
--- a/data_ingestion.py
+++ b/data_ingestion.py
@@ -290,8 +290,6 @@ if __name__ == '__main__':
     else:
         print("\nNo Security Notices data loaded or an error occurred.")
 
-    print("\nNo Security Notices data loaded or an error occurred.")
-
     print("\n--- Testing fetch_nrf_security_advisories ---")
     nrf_advisories = fetch_nrf_security_advisories()
     if nrf_advisories:


### PR DESCRIPTION
## Summary
- remove redundant print statement in `data_ingestion.py`

## Testing
- `python3 -m py_compile data_ingestion.py`
- `python3 data_ingestion.py` *(fails: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684255246fe483258004f8225f0feda7