### PR TITLE
Fix Quick Start section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ A forensic dashboard for visualizing and reporting Bluetooth Low Energy (BLE), W
 ## **Quick Start (Local)**
 ```bash
 pip install -r requirements.txt
-python ble_dashboard.py
+python Script
+```
 
 ---
 


### PR DESCRIPTION
## Summary
- close the shell code block in README
- update startup command to use the correct script name

## Testing
- `python -m py_compile Script data_ingestion.py`

------
https://chatgpt.com/codex/tasks/task_e_68425525da6c83258fed6f9c964ea46c